### PR TITLE
Give the per-ticket plan a real interview gate

### DIFF
--- a/.claude/skills/piv-plan-implementation/SKILL.md
+++ b/.claude/skills/piv-plan-implementation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: piv-plan-implementation
-description: Creates a comprehensive, context-rich implementation plan through deep codebase analysis and external research. Accepts a tracker ticket (a Jira/Linear/GitHub key or URL, fetched from the tracker) or a free-form feature request. Use when you have a ticket or feature and need a one-pass-ready plan before writing any code.
+description: Creates a comprehensive, context-rich implementation plan through deep codebase analysis, a short clarifying interview, and external research. Accepts a tracker ticket (a Jira/Linear/GitHub key or URL, fetched from the tracker) or a free-form feature request. Use when you have a ticket or feature and need a one-pass-ready plan before writing any code.
 argument-hint: "[ticket key/URL (fetched from your tracker), or a free-form feature description]"
 ---
 
@@ -96,11 +96,36 @@ So that <benefit/value>
 - Understand database/model patterns if applicable
 - Identify authentication/authorization patterns if relevant
 
-**Clarify Ambiguities:**
+**Clarify Ambiguities — GATE:**
 
-- If requirements are unclear at this point, ask the user to clarify before you continue
-- Get specific implementation preferences (libraries, approaches, patterns)
-- Resolve architectural decisions before proceeding
+Codebase analysis is done, so the open questions are now *specific*. This is the one moment where you know
+enough to ask well and have not yet written anything. **GATE** means: post the questions, then stop. End the
+turn and wait for the answers. Do not ask and answer in the same breath, and do not roll into Phase 3.
+
+Ask in **one cluster**, numbered, 3-6 questions max, each carrying a **recommended default** so answering is
+cheap ("I'll mirror the first unless you say otherwise"). Draw them only from what the analysis actually left
+open:
+
+1. **Scope boundary** — the adjacent thing a reasonable reader would assume is in scope. Confirm it is out.
+2. **Pattern fork** — two existing patterns both fit. Name both with `file:line` and ask which to mirror.
+3. **Contract shape** — the API surface, payload, or data-model change the ticket implies but never states.
+4. **Failure behavior** — what happens on the error path the ticket is silent about.
+5. **Preference** — a library or trade-off with no precedent in this codebase to inherit.
+6. **Done** — an acceptance criterion that is missing, or written so that it cannot be checked.
+
+Skip any category with nothing genuinely open; never manufacture questions to fill the list. If the ticket, its
+epic and the architecture doc genuinely settle everything, say so in one line and proceed. Silence is not the
+same as clearance.
+
+**Thin answers:** reflect a vague answer back as the concrete choice it leaves open ("'handle errors gracefully'
+— a 4xx with a message, or retry then 503?") and ask once more. Never upgrade a vague answer into a confident plan.
+
+**If they decline** ("just write it"): honour it, but name what you are guessing. Every unanswered item becomes
+an `Assumed — <the assumption>, confirm before execution` line in `OPEN QUESTIONS / ASSUMPTIONS`, and the task it
+affects carries a `**GOTCHA**` naming it. Never guess silently.
+
+**Already settled upstream:** anything the ticket, its epic, or the linked architecture page already answers is
+not open. Inherit it and skip (see "Inherit, don't re-decide").
 
 ### Phase 3: External Research & Documentation
 
@@ -442,6 +467,7 @@ Execute every command to ensure zero regressions and 100% feature correctness.
 - [ ] Integration points clearly mapped
 - [ ] Gotchas and anti-patterns captured
 - [ ] Every task has executable validation command
+- [ ] Phase 2's clarifying cluster was asked and answered, or explicitly recorded as nothing open
 
 ### Implementation Ready ✓
 
@@ -466,7 +492,7 @@ Execute every command to ensure zero regressions and 100% feature correctness.
 
 ## Success Metrics
 
-**One-Pass Implementation**: Execution agent can complete feature without additional research or clarification
+**One-Pass Implementation**: Execution agent can complete feature without additional research or clarification — clarification the *user* owes the plan belongs in Phase 2's gate, not deferred to the execution agent
 
 **Validation Complete**: Every task has at least one working validation command
 

--- a/.claude/skills/plan-create-prd/SKILL.md
+++ b/.claude/skills/plan-create-prd/SKILL.md
@@ -44,7 +44,13 @@ A sharp product manager who: starts with **problems, not solutions**; demands **
 INITIATE → FOUNDATION → DEEP DIVE → HYPOTHESIS → MVP & DOORS → GENERATE
 ```
 
-Ask in **clusters** and **GATE** — wait for answers before moving on; reflect thin answers back and dig.
+Ask in **clusters** and **GATE**. **GATE** means: post the cluster, then stop. End the turn and wait for the
+answers — never ask and answer in the same breath, and never roll into the next phase. Reflect thin answers back
+and dig.
+
+**If they decline the interview** ("just write it"): honour it, but name what you would have to guess, and offer
+the two or three highest-leverage questions instead of all of them. Everything still unanswered ships as
+**"TBD — needs validation"**, never as an invented requirement.
 
 ### Phase 1 — Initiate
 Input given → restate and confirm. Blank → *"What do you want to build? A few sentences."* **GATE.**


### PR DESCRIPTION
## Why

`piv-plan-implementation` is described as the skill that interviews you before it plans. It did not. In 486 lines it contained **no gate** (zero instances of `GATE`, `wait`, or `stop`), no scripted question, and no phase that ended in a user turn.

Its only clarification block was three bullets triggered by the model's own judgement:

> - If requirements are unclear at this point, ask the user to clarify before you continue

And the structural incentive ran the other way. The stated success metric was *"Execution agent can complete feature without additional research or clarification"* — which rewards **not** asking. In practice the skill one-shot a 400-line plan from a one-line feature request.

`plan-create-prd` already works well (five gates at named phase boundaries, a thin-answer protocol, and an output contract whose required fields make a skipped interview self-evident). It had two small holes: `GATE` was never defined as a turn boundary, and nothing covered a user who declines the interview.

## What changed

**`piv-plan-implementation`** — the gate goes in Phase 2, after codebase analysis, because that is the one moment where the questions can be *specific* and nothing has been written yet. Phases 3 to 5 all remain downstream of it.

- Replaced the three `Clarify Ambiguities` bullets with a real **GATE**: explicit turn boundary, one numbered cluster of 3-6 questions drawn from six named categories (scope boundary, pattern fork, contract shape, failure behavior, preference, done), each with a recommended default so answering is cheap.
- Added a thin-answer protocol, an explicit path for "just write it", and a rule against manufacturing questions when nothing is genuinely open.
- The `One-Pass Implementation` metric no longer reads as "don't ask".
- A quality checkbox so a skipped cluster is visible after the fact, and the description now names the interview.

**`plan-create-prd`** — minimal, since it already worked.

- `GATE` now states the turn boundary explicitly.
- Covers the one case it missed: the user who declines. Honour it, name what you would have to guess, offer the highest-leverage questions instead, and ship the rest as `TBD — needs validation` rather than inventing requirements.

## Scope

`+38 / -6` across two files. No other skill touched.