### PR TITLE
Make the public repo stand on its own

### DIFF
--- a/.claude/skills/piv-implement/SKILL.md
+++ b/.claude/skills/piv-implement/SKILL.md
@@ -51,6 +51,9 @@ For EACH task in "Step by Step Tasks":
 - After each file change, check syntax
 - Ensure imports are correct
 - Verify types are properly defined
+- **Run the task's own `VALIDATE` command before starting the next task.** Every task in the plan carries one.
+  A task is not done until its check passes — if it fails, fix it now rather than carrying the failure forward.
+  The full suite still runs at step 4; this is the per-task gate that keeps step 4 from becoming a pile-up.
 
 ### 3. Implement Testing Strategy
 

--- a/.claude/skills/piv-investigate-issue/SKILL.md
+++ b/.claude/skills/piv-investigate-issue/SKILL.md
@@ -40,8 +40,8 @@ search stays out of your main context:
 - **`research-agent`** (a second explorer) — find WHERE the relevant code lives + patterns to mirror: the error
   strings from the issue, related functions/modules, similar implementations, existing test patterns.
 
-Merge their findings into a short map (`file:line` + why each matters) before forming the root cause. *(This is the
-V15/V20 fan-out, applied to diagnosis.)*
+Merge their findings into a short map (`file:line` + why each matters) before forming the root cause. *(This is
+the parallel-subagent fan-out, applied to diagnosis.)*
 
 ### 3. Review Recent History — when was it introduced?
 

--- a/.claude/skills/piv-review-pr/SKILL.md
+++ b/.claude/skills/piv-review-pr/SKILL.md
@@ -41,7 +41,7 @@ lint, build. Capture pass/fail + counts. A red suite is a finding in itself.
 
 ## Phase 4 — Review the diff (dispatch the code-reviewer agent)
 
-Hand the deep pass to the **`code-reviewer` agent** (`.claude/agents/code-reviewer.md`) — it reviews against the
+Hand the deep pass to a **`code-reviewer` subagent** if the project has one (`.claude/agents/code-reviewer.md`); otherwise review in this session, in a clean context — it reviews against the
 project's standards and reports **high-confidence issues only**. Read every changed file *in full* (not just the
 diff) for context. Cover: correctness · type safety · pattern/standards compliance · security · performance ·
 tests present · maintainability.
@@ -89,5 +89,5 @@ next step is **`piv-fix-review-findings`** on the report, then re-run validation
 - **Fresh eyes is the whole point** — run this in a clean context (or let the `code-reviewer` agent be the clean
   context). Don't review with the session that wrote the code; it rationalizes instead of scrutinizing.
 - This is the *agentic* gate; it does not replace the human — it gives the human a validated, triaged PR to
-  approve. Going deeper (multiple review agents, tuning the reviewer to your stack, the validation pyramid) is
-  the code-review-as-a-component material later in the course.
+  approve. Going deeper means multiple review agents, tuning the reviewer to your stack, and a validation
+  pyramid behind it.

--- a/.claude/skills/plan-create-prd/SKILL.md
+++ b/.claude/skills/plan-create-prd/SKILL.md
@@ -129,7 +129,7 @@ sections only, scannable:
 
 ## Notes
 
-- Interview-led; never generate from thin air. Greenfield-first (on an existing product the epic comes from V6, and you decide its architecture in V7 with `plan-architecture`).
+- Interview-led; never generate from thin air. Greenfield-first. On an existing product the epic is the input, and you decide its architecture separately with `plan-architecture`.
 - **Solo builder?** Building *for yourself* → you're the user; prove or kill it on yourself fast, you can jump
   closer to a solution. Building *for someone else* → you can't introspect their needs; building it *right*
   beats building it. Either way: thinnest MVP + experiments is how you learn what "right" is.

--- a/.claude/skills/rules-create-global/SKILL.md
+++ b/.claude/skills/rules-create-global/SKILL.md
@@ -62,7 +62,7 @@ Global rules encode **technical** truth — so you derive them from technical de
 > so the structure, key files, and conventions are loaded into this conversation, then run this skill with no path.
 > (Large repo? Optionally fan out a few built-in subagents to explore areas in parallel, aggregate a short
 > `codebase-analysis.md`, and pass that path instead.) This skill packages the *derive → extract → seams → prune → check*
-> steps you saw in V5, not the exploration.
+> steps, not the exploration.
 
 > **Before you run this — protect any existing rules.** If the project already has a `CLAUDE.md` /
 > `AGENTS.md`, **copy or rename it first** (e.g. `CLAUDE.md.bak`) so this skill doesn't overwrite something
@@ -80,7 +80,7 @@ Global rules encode **technical** truth — so you derive them from technical de
 - **Neither yet?** `CLAUDE.md` for a Claude-Code-only project; `AGENTS.md` if the team is multi-tool.
 
 Content + structure are ~90% identical either way — everything below is **"your rules file,"** not one vendor's.
-Use the course's **`.claude/CLAUDE.md.template`** as the structure (it works as an AGENTS.md too).
+Use the structure laid out below (it works as an AGENTS.md just as well).
 
 ## The methodology (bake this in)
 
@@ -115,7 +115,7 @@ Use the course's **`.claude/CLAUDE.md.template`** as the structure (it works as 
   code either way. Not primed and no path passed? Run `/prime-codebase` first.
 - **If a rules file already exists:** read it first and treat it as a starting point — and make sure it's
   backed up (see "protect any existing rules" above) so nothing you wrote by hand is lost.
-- Read the best-practices docs above. Load `.claude/CLAUDE.md.template` as the structure.
+- Read the best-practices docs above. Follow the structure laid out in this skill.
 
 ### 2. Derive the root `CLAUDE.md`
 Fill the template's sections, sourced from the input:

--- a/.claude/skills/skills-create/SKILL.md
+++ b/.claude/skills/skills-create/SKILL.md
@@ -12,8 +12,8 @@ A skill that authors and refactors skills. Two jobs:
 - **Refactor** a fat skill — split detail into `references/`, move output shapes into `templates/`, trim
   `SKILL.md` down to a lean spine of pointers.
 
-**It's built the way it teaches:** a lean body that defers detail to `references/`. That's progressive disclosure
-(the V19 lesson) — and this skill is its own worked example. **It's all composable markdown:** a skill is a
+**It's built the way it teaches:** a lean body that defers detail to `references/`. That's progressive
+disclosure, and this skill is its own worked example. **It's all composable markdown:** a skill is a
 `SKILL.md` plus optional files the agent loads only when it reaches for them.
 
 ## Prescribe the craft, not the content
@@ -27,8 +27,8 @@ Be **strict on how a skill is built** and **agnostic on what any given skill —
   output shape, which phases exist. There is no canonical output — guide the author to a good decision, never hand
   them a fixed one.
 
-Strict on the craft so the author stays free on the content. *(This is the course's "guide, don't prescribe" — and
-take-vs-build: you **build** a skill when you own the process and want it to follow YOUR way.)*
+Strict on the craft so the author stays free on the content. *(Guide, don't prescribe — and take-vs-build: you
+**build** a skill when you own the process and want it to follow YOUR way.)*
 
 ## Classify the skill first
 
@@ -81,8 +81,8 @@ Both modes obey the same craft rules → read `references/skill-standards.md` fi
 > forgets to read it and the output silently changes. Always pair such an extraction with a mandatory-read line.
 
 ## When to build a skill at all
-Build one when you **own a process** and want the agent to follow *your* way of it, repeatedly — the take-vs-build
-rule from V19. A rough threshold: you've prompted the same thing ~3 times (the Rule of Three) → bank it as a skill.
+Build one when you **own a process** and want the agent to follow *your* way of it, repeatedly — the
+take-vs-build rule. A rough threshold: you've prompted the same thing ~3 times (the Rule of Three) → bank it as a skill.
 Don't build a skill for a one-off, or for a tool whose owner already ships a good one.
 
 ## Resources

--- a/.claude/skills/worktree-merge/SKILL.md
+++ b/.claude/skills/worktree-merge/SKILL.md
@@ -61,5 +61,5 @@ linter). Do not hardcode `pytest`/`mypy`/`pyright` — use whatever this repo ac
 
 - `--no-ff` preserves each feature branch's history.
 - The integration branch is disposable — the original branch only moves after every merge and the full suite pass.
-- Prefer opening a PR per branch (the reviewed path from V9) when you're on a team; this skill is for fast local
+- Prefer opening a PR per branch when you're on a team; this skill is for fast local
   integration when you own the merge.

--- a/README.md
+++ b/README.md
@@ -176,8 +176,9 @@ Two things deliberately ship as templates and expect an edit before first use:
 
 - **`piv-validate`** has a placeholder command list. Put your project's real test, type-check, and lint commands
   in it.
-- **`piv-commit`**, **`piv-create-pr`**, and the **`piv-review-*`** skills read `.claude/references/conventions.md`
-  if it exists. Create one and they'll follow your conventions instead of guessing.
+- **`piv-commit`** and **`piv-create-pr`** read `.claude/references/conventions.md` if it exists, the first its
+  `## commit` section and the second its `## pr` section. Create one and they'll follow your conventions instead
+  of guessing.
 
 `piv-review-pr` will hand its deep pass to a `code-reviewer` subagent if you have one in `.claude/agents/`. Without
 it, the skill still works, it just does the review inline.


### PR DESCRIPTION
Cleanup pass over everything a viewer hits when they open a skill after installing.

**Course-internal references stripped.** Lesson numbers (V5, V6, V7, V9, V15, V19, V20) and "later in the course" pointers across six skills. They are meaningless to anyone who has not taken the course. `plan-create-prd` had the most visible one.

**Two broken pointers fixed.**
- `rules-create-global` instructed the agent to load `.claude/CLAUDE.md.template`, which this repo does not ship. Anyone running the skill hit an instruction pointing at a missing file. Both occurrences now point at the structure the skill already lays out inline.
- `piv-review-pr` hard-coded `.claude/agents/code-reviewer.md`. The README already hedged this ("if you have one"); the skill now matches and falls back to a clean-context review.

**README corrected.** It claimed `piv-commit`, `piv-create-pr` *and the `piv-review-*` skills* read `conventions.md`. Only the first two do.

**`piv-implement` now honours the plan's per-task checks.** Its description promised "validation at every step" and every task in a plan carries a `VALIDATE` command, but the body only checked syntax, imports and types per task and left the real commands to run in bulk at the end. It now runs each task's check before starting the next, so a failure surfaces at the task that caused it.